### PR TITLE
Fix: Analog clock size increases on each redraw

### DIFF
--- a/script.js
+++ b/script.js
@@ -266,13 +266,16 @@ function updateClockTimes() {
 function drawAnalogClock(canvas, instant, tz) {
   const ctx = canvas.getContext('2d');
   const DPR = window.devicePixelRatio || 1;
-  const size = Math.min(canvas.width, canvas.height);
+  const size = canvas.clientWidth; // Use clientWidth for stable size
   const r = size / 2;
-  // scale for DPR
-  canvas.width = size * DPR;
-  canvas.height = size * DPR;
-  canvas.style.width = (size/2) + 'px';
-  canvas.style.height = (size/2) + 'px';
+
+  // Set actual canvas drawing surface size based on DPR
+  if (canvas.width !== size * DPR) {
+    canvas.width = size * DPR;
+    canvas.height = size * DPR;
+  }
+
+  // Scale context for high-DPI rendering
   ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
   ctx.clearRect(0,0,size,size);
   ctx.translate(r, r);


### PR DESCRIPTION
The `drawAnalogClock` function was previously reading the canvas's `width` and `height` attributes and then setting them again after multiplying by the device pixel ratio. This created a feedback loop, causing the clock's dimensions to grow with each update.

This commit fixes the issue by using the `clientWidth` property of the canvas to get a stable, CSS-defined size. The canvas's drawing surface is still scaled by the device pixel ratio for high-DPI rendering, but its visible size on the page is no longer modified by the script.